### PR TITLE
Unify targeting config evaluation

### DIFF
--- a/adapter-proxy-wasm/Cargo.lock
+++ b/adapter-proxy-wasm/Cargo.lock
@@ -4,9 +4,9 @@
 name = "adapter-proxy-wasm"
 version = "0.1.0"
 dependencies = [
- "chrono 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-plane 0.1.0",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proxy-wasm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -14,12 +14,12 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -37,7 +37,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -47,11 +47,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -60,7 +60,7 @@ name = "data-plane"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -72,13 +72,13 @@ name = "hashbrown"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ahash 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ahash 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -88,12 +88,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -111,16 +111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -128,10 +128,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.14"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -140,16 +140,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hashbrown 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wee_alloc 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -170,7 +170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -186,9 +186,9 @@ name = "serde_derive"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -196,19 +196,19 @@ name = "serde_json"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -224,13 +224,13 @@ name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -239,14 +239,14 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -273,37 +273,37 @@ dependencies = [
 ]
 
 [metadata]
-"checksum ahash 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2f3e0bf23f51883cce372d5d5892211236856e4bb37fb942e1eb135ee0f146e3"
-"checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+"checksum ahash 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+"checksum aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 "checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+"checksum base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum chrono 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f0fee792e164f78f5fe0c296cc2eb3688a2ca2b70cdff33040922d298203f0c4"
+"checksum chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 "checksum hashbrown 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
-"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)" = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)" = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+"checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
-"checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
-"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
-"checksum proc-macro2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "de40dd4ff82d9c9bab6dae29dbab1167e515f8df9ed17d2987cb6012db206933"
+"checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+"checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 "checksum proxy-wasm 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "211b32bad8246f4126c757a3de13581fd79c661aeb97f595e63f143da77b1d48"
-"checksum quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 "checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
-"checksum ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+"checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 "checksum serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)" = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
-"checksum syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
+"checksum syn 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 "checksum wee_alloc 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+"checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum woothee 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89d5a45c5d9c772e577c263597681448fd91a46aed911783394eec396e45d4ee"

--- a/adapter-proxy-wasm/Cargo.toml
+++ b/adapter-proxy-wasm/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-chrono = "0.4.12"
+chrono = "0.4.13"
 data-plane = { path = "../data-plane" }
-log = "0.4.8"
+log = "0.4.11"
 proxy-wasm = "0.1.0"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.56"

--- a/adapter-proxy-wasm/filter-config.json
+++ b/adapter-proxy-wasm/filter-config.json
@@ -2,13 +2,21 @@
   "header_name": "x-features",
   "explicit": [
     {
-      "_extract": "list",
-      "attribute": "x-feature-override"
+      "split": {
+        "separator": " ",
+        "value": {
+          "attribute": "x-feature-override"
+        }
+      }
     },
     {
-      "_extract": "pattern",
-      "attribute": ":authority",
-      "pattern": "f-*.localhost:8080"
+      "extract": {
+        "regex": "f-([a-z0-9-]+)",
+        "value": {
+          "attribute": ":authority"
+        }
+      }
     }
-  ]
+  ],
+  "implicit": []
 }

--- a/data-plane/Cargo.lock
+++ b/data-plane/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -13,7 +13,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -23,16 +23,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ctor"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -40,12 +40,12 @@ name = "data-plane"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "woothee 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -57,7 +57,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -75,7 +75,7 @@ name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,25 +84,25 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ctor 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -110,7 +110,7 @@ name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -128,40 +128,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -169,9 +169,9 @@ name = "test-case"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -195,7 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -222,31 +222,31 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+"checksum aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
-"checksum base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
-"checksum ctor 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d"
+"checksum base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+"checksum ctor 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
-"checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
-"checksum quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 "checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-"checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
-"checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
-"checksum serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
-"checksum syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+"checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+"checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+"checksum serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)" = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+"checksum syn 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "fb7f4c519df8c117855e19dd8cc851e89eb746fe7a73f0157e0d95fdec5369b0"
 "checksum test-case 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "199464148b42bcf3da8b2a56f6ee87ca68f47402496d1268849291ec9fb463c8"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+"checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum woothee 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89d5a45c5d9c772e577c263597681448fd91a46aed911783394eec396e45d4ee"

--- a/data-plane/Cargo.toml
+++ b/data-plane/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.31"
-serde = { version = "1.0.111", features = ["derive"] }
-serde_json = "1.0.53"
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.56"
 regex = "1.3.9"
 woothee = "0.11.0"
-base64 = "0.12.1"
+base64 = "0.12.3"
 
 [dev-dependencies]
 test-case = "1.0.0"

--- a/data-plane/src/features/explicit.rs
+++ b/data-plane/src/features/explicit.rs
@@ -7,7 +7,6 @@ pub fn from_request(request: &HashMap<&str, &str>, config: &Config) -> Vec<Strin
         .0
         .iter()
         .flat_map(|x| x.eval(request).unwrap_or_else(|_| vec![]))
-        .map(|s| s)
         .collect::<Vec<_>>();
 
     features.sort();

--- a/data-plane/src/features/explicit.rs
+++ b/data-plane/src/features/explicit.rs
@@ -1,12 +1,14 @@
+use crate::features::expression::{Str, StrList};
 use serde::Deserialize;
 use std::collections::HashMap;
 
-pub fn from_request<'a>(request: &HashMap<&str, &'a str>, config: &Config) -> Vec<&'a str> {
+pub fn from_request(request: &HashMap<&str, &str>, config: &Config) -> Vec<String> {
     let mut features = config
         .0
         .iter()
-        .flat_map(|x| x.extract(request))
-        .collect::<Vec<&str>>();
+        .flat_map(|x| x.eval(request).unwrap_or_else(|_| vec![]))
+        .map(|s| s)
+        .collect::<Vec<_>>();
 
     features.sort();
 
@@ -15,81 +17,15 @@ pub fn from_request<'a>(request: &HashMap<&str, &'a str>, config: &Config) -> Ve
 
 /// Configuration
 #[derive(Debug, Deserialize)]
-pub struct Config(pub Vec<Extract>);
+pub struct Config(pub Vec<StrList>);
 
 impl Default for Config {
     fn default() -> Self {
-        Self(vec![Extract::List(List {
-            attribute: "x-feature-overrides".to_owned(),
-        })])
+        Self(vec![StrList::Split {
+            separator: " ".to_owned(),
+            value: Str::Attribute("x-feature-overrides".to_owned()),
+        }])
     }
-}
-
-// Ways of extracting feature names from a request
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "_extract", rename_all = "snake_case")]
-pub enum Extract {
-    List(List),
-    Pattern(Pattern),
-}
-
-impl Extract {
-    fn extract<'a>(&self, request: &HashMap<&str, &'a str>) -> Vec<&'a str> {
-        match self {
-            Extract::List(l) => l.extract(request),
-            Extract::Pattern(p) => p.extract(request),
-        }
-    }
-}
-
-/// List of features in an attribute
-#[derive(Debug, Deserialize)]
-pub struct List {
-    pub attribute: String,
-}
-
-impl List {
-    fn extract<'a>(&self, request: &HashMap<&str, &'a str>) -> Vec<&'a str> {
-        if let Some(value) = request.get::<str>(self.attribute.as_ref()) {
-            return value.split_whitespace().collect();
-        }
-
-        vec![]
-    }
-}
-
-// Pattern matching on an attribute
-
-#[derive(Debug, Deserialize)]
-pub struct Pattern {
-    pub attribute: String,
-    pub pattern: String,
-}
-
-impl Pattern {
-    fn extract<'a>(&self, request: &HashMap<&str, &'a str>) -> Vec<&'a str> {
-        if let Some(value) = request.get::<str>(self.attribute.as_ref()) {
-            return match_pattern(value, self.pattern.as_ref()).map_or(vec![], |v| vec![v]);
-        }
-
-        vec![]
-    }
-}
-
-fn match_pattern<'a>(value: &'a str, pattern: &str) -> Option<&'a str> {
-    let tokens = pattern.split('*').collect::<Vec<&str>>();
-
-    let (prefix, postfix) = match &tokens[..] {
-        [prefix, postfix] => (prefix, postfix),
-        _ => return None,
-    };
-
-    if !value.starts_with(prefix) || !value.ends_with(postfix) {
-        return None;
-    }
-
-    Some(value.trim_start_matches(prefix).trim_end_matches(postfix))
 }
 
 #[cfg(test)]
@@ -102,13 +38,14 @@ mod test {
     lazy_static! {
         static ref CONFIG: Config = {
             Config(vec![
-                Extract::Pattern(Pattern {
-                    attribute: "host".to_owned(),
-                    pattern: "f-*.echo.localhost".to_owned(),
-                }),
-                Extract::List(List {
-                    attribute: "x-features".to_owned(),
-                }),
+                StrList::Extract {
+                    value: Box::new(Str::Attribute("host".to_owned())),
+                    regex: r#"f-([a-z]+)\.echo\.localhost"#.to_owned(),
+                },
+                StrList::Split {
+                    separator: " ".to_owned(),
+                    value: Str::Attribute("x-features".to_owned()),
+                },
             ])
         };
     }
@@ -133,16 +70,5 @@ mod test {
         }
 
         map
-    }
-
-    #[test_case("*", "foo", Some("foo"); "only match")]
-    #[test_case("a-*", "a-foo", Some("foo"); "prefix match")]
-    #[test_case("*-a", "foo-a", Some("foo"); "postfix match")]
-    #[test_case("aa-*-ab", "aa-foo-ab", Some("foo"); "infix match")]
-    #[test_case("aa-*", "foo", None; "prefix not match")]
-    #[test_case("aa-*-*-bb", "foo", None; "multiple wildcards")]
-    #[test_case("aa", "foo", None; "no wildcard")]
-    fn substring_matching(pattern: &str, value: &str, mtch: Option<&str>) {
-        assert_eq!(match_pattern(value, pattern), mtch)
     }
 }

--- a/data-plane/src/features/explicit.rs
+++ b/data-plane/src/features/explicit.rs
@@ -1,5 +1,5 @@
 use crate::features::expression::{Str, StrList};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub fn from_request(request: &HashMap<&str, &str>, config: &Config) -> Vec<String> {
@@ -16,7 +16,7 @@ pub fn from_request(request: &HashMap<&str, &str>, config: &Config) -> Vec<Strin
 }
 
 /// Configuration
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Config(pub Vec<StrList>);
 
 impl Default for Config {
@@ -32,6 +32,8 @@ impl Default for Config {
 mod test {
     use super::*;
     use lazy_static::lazy_static;
+    use pretty_assertions::assert_eq as assert_eq_diff;
+    use serde_json::json;
     use std::collections::HashMap;
     use test_case::test_case;
 
@@ -70,5 +72,27 @@ mod test {
         }
 
         map
+    }
+
+    #[test]
+    fn serialises_to_json() {
+        let expected = json!([
+            {
+                "extract": {
+                    "regex": r#"f-([a-z]+)\.echo\.localhost"#,
+                    "value": { "attribute": "host" }
+                }
+            },
+            {
+                "split": {
+                    "separator": " ",
+                    "value": { "attribute": "x-features" }
+                }
+            }
+        ])
+        .to_string();
+        let actual = serde_json::to_string(&*CONFIG).unwrap();
+
+        assert_eq_diff!(actual, expected);
     }
 }

--- a/data-plane/src/features/expression/mod.rs
+++ b/data-plane/src/features/expression/mod.rs
@@ -1,0 +1,518 @@
+use anyhow::{anyhow, Result};
+use base64::decode as base64decode;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap, HashSet},
+    hash::{Hash, Hasher},
+};
+use woothee::parser::{Parser as UserAgentParser, WootheeResult};
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Bool {
+    /// The identity expression
+    Constant(bool),
+    /// Request attribute of name is present
+    Attribute(String),
+    /// Value contained in the list
+    In { list: StrList, value: Str },
+    /// Any of the values contained in the list
+    AnyIn { list: StrList, values: StrList },
+    /// All of the values contained in the list
+    AllIn { list: StrList, values: StrList },
+    /// Looks up a boolean value by a JSON Pointer
+    ///
+    /// JSON Pointer defines a string syntax for identifying a specific value
+    /// within a JavaScript Object Notation (JSON) document.
+    ///
+    /// A Pointer is a Unicode string with the reference tokens separated by `/`.
+    /// Inside tokens `/` is replaced by `~1` and `~` is replaced by `~0`. The
+    /// addressed value is returned and if there is no such value `None` is
+    /// returned.
+    ///
+    /// For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
+    JsonPointer { pointer: String, value: Str },
+    /// Matches a Regular ession
+    Matches(String, Str),
+    /// == for strings
+    StrEq(Str, Str),
+    /// == for numbers
+    NumEq(Num, Num),
+    /// > for numbers
+    Gt(Num, Num),
+    /// < for numbers
+    Lt(Num, Num),
+    /// >= for numbers
+    Gte(Num, Num),
+    /// <= for numbers
+    Lte(Num, Num),
+    /// Logical NOT
+    Not(Box<Bool>),
+    /// Logical AND
+    And(Vec<Bool>),
+    /// Logical OR
+    Or(Vec<Bool>),
+}
+
+impl Bool {
+    pub fn eval(&self, request: &HashMap<&str, &str>) -> Result<bool> {
+        use Bool::*;
+        match self {
+            Constant(c) => Ok(*c),
+            Attribute(name) => request
+                .get::<str>(&name)
+                .map(|_| true)
+                .ok_or_else(|| anyhow!("Attribute '{}' not found.", name)),
+            In { list, value } => list
+                .eval(request)
+                .and_then(|haystack| value.eval(request).map(|needle| haystack.contains(&needle))),
+            AnyIn { list, values } => list.eval(request).and_then(|haystack| {
+                values.eval(request).map(|needles| {
+                    let a: HashSet<_> = haystack.iter().collect();
+                    let b: HashSet<_> = needles.iter().collect();
+
+                    a.intersection(&b).next().is_some()
+                })
+            }),
+            AllIn { list, values } => list.eval(request).and_then(|haystack| {
+                values.eval(request).map(|needles| {
+                    let a: HashSet<_> = haystack.iter().collect();
+                    let b: HashSet<_> = needles.iter().collect();
+
+                    a.intersection(&b).count() == a.len()
+                })
+            }),
+            JsonPointer { pointer, value } => value
+                .eval(request)
+                .and_then(|json| json_pointer(&pointer, &json, "boolean", |v| v.as_bool())),
+            Matches(regex, value) => {
+                let v = value.eval(request)?;
+                let r = Regex::new(&regex)?;
+                Ok(r.is_match(&v))
+            }
+            StrEq(left, right) => {
+                let l = left.eval(request)?;
+                let r = right.eval(request)?;
+                Ok(l == r)
+            }
+            NumEq(left, right) => {
+                let l = left.eval(request)?;
+                let r = right.eval(request)?;
+                Ok((l - r).abs() < std::f64::EPSILON)
+            }
+            Gt(left, right) => {
+                let l = left.eval(request)?;
+                let r = right.eval(request)?;
+                Ok(l > r)
+            }
+            Lt(left, right) => {
+                let l = left.eval(request)?;
+                let r = right.eval(request)?;
+                Ok(l < r)
+            }
+            Gte(left, right) => {
+                let l = left.eval(request)?;
+                let r = right.eval(request)?;
+                Ok(l >= r)
+            }
+            Lte(left, right) => {
+                let l = left.eval(request)?;
+                let r = right.eval(request)?;
+                Ok(l <= r)
+            }
+            Not(value) => value.eval(request).map(|v| !v),
+            And(values) => values
+                .iter()
+                .map(|v| v.eval(request))
+                .collect::<Result<Vec<_>, _>>()
+                .map(|it| it.iter().all(|v| *v)),
+            Or(values) => values
+                .iter()
+                .map(|v| v.eval(request))
+                .collect::<Result<Vec<_>, _>>()
+                .map(|it| it.iter().any(|v| *v)),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum StrList {
+    /// The identity expression
+    Constant(Vec<String>),
+    /// Split a string value using a separator
+    Split { separator: String, value: Str },
+    /// Extract using a regular expression
+    ///
+    /// provided regex string must have at least one capture group
+    Extract { regex: String, value: Box<Str> },
+    /// Parse a HTTP header with q-values,
+    /// i.e. Accept, Accept-Charset, Accept-Language, Accept-Encoding
+    HttpQualityValue(Str),
+}
+
+impl StrList {
+    pub fn eval(&self, request: &HashMap<&str, &str>) -> Result<Vec<String>> {
+        use StrList::*;
+        match self {
+            Constant(c) => Ok(c.clone()),
+            Split { separator, value } => {
+                let s = value.eval(request)?;
+                if s == "" {
+                    return Ok(vec![]);
+                }
+
+                Ok(s.split(separator).map(|s| s.to_string()).collect())
+            }
+            Extract { regex, value } => {
+                let value = value.eval(request)?;
+                let regex = Regex::new(regex)?;
+
+                let captures = regex.captures(&value).ok_or(anyhow!(
+                    "'{}' does not match '{}'",
+                    value,
+                    regex
+                ))?;
+
+                Ok(captures
+                    .iter()
+                    .filter_map(|m| m.map(|s| s.as_str().to_string()))
+                    .skip(1)
+                    .collect())
+            }
+            HttpQualityValue(value) => {
+                let s = value.eval(request)?;
+                Ok(parse_q_value(&s).iter().map(|s| s.to_string()).collect())
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Str {
+    /// The identity expression
+    Constant(String),
+    /// Request attribute value
+    Attribute(String),
+    /// Base 64 decode value
+    Base64(Box<Str>),
+    /// Extract using a regular expression
+    ///
+    /// provided regex string must have one capture group
+    Extract { regex: String, value: Box<Str> },
+    /// Value of a cookie by name
+    Cookie(String),
+    /// Derives browser from User-Agent
+    Browser,
+    /// Derives bowser version from User-Agent
+    BrowserVersion,
+    /// Derives operating system from User-Agent
+    OperatingSystem,
+    /// Looks up a string value by a JSON Pointer
+    ///
+    /// JSON Pointer defines a string syntax for identifying a specific value
+    /// within a JavaScript Object Notation (JSON) document.
+    ///
+    /// A Pointer is a Unicode string with the reference tokens separated by `/`.
+    /// Inside tokens `/` is replaced by `~1` and `~` is replaced by `~0`. The
+    /// addressed value is returned and if there is no such value `None` is
+    /// returned.
+    ///
+    /// For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
+    JsonPointer { pointer: String, value: Box<Str> },
+    /// First item of a list
+    First(Box<StrList>),
+    /// Last item of a list
+    Last(Box<StrList>),
+}
+
+impl Str {
+    pub fn eval(&self, request: &HashMap<&str, &str>) -> Result<String> {
+        use Str::*;
+        match self {
+            Constant(c) => Ok(c.clone()),
+            Attribute(name) => request.get::<str>(name).map_or_else(
+                || Err(anyhow!("Attribute '{}' not found.", name)),
+                |s| Ok((*s).to_string()),
+            ),
+            Base64(value) => {
+                // Transformations like this one mean we can't use string slices
+                // as output, as the return values are not simply substrings of
+                // the request or the config
+                let s = value.eval(request)?;
+                let bytes = base64decode(s)?;
+                let v = String::from_utf8(bytes)?;
+
+                Ok(v)
+            }
+            Extract { regex, value } => {
+                let value = value.eval(request)?;
+                let regex = Regex::new(regex)?;
+
+                regex
+                    .captures(&value)
+                    .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))
+                    .ok_or(anyhow!("'{}' does not match '{}'", value, regex))
+            }
+            Cookie(name) => get_cookie(request, name).map(|s| s.to_string()),
+            Browser => map_user_agent(request, |ua| ua.name.to_string()),
+            BrowserVersion => map_user_agent(request, |ua| ua.version.to_string()),
+            OperatingSystem => map_user_agent(request, |ua| ua.os.to_string()),
+            JsonPointer { pointer, value } => {
+                let json = value.eval(request)?;
+                json_pointer(pointer, &json, "string", |v| {
+                    v.as_str().map(|s| s.to_string())
+                })
+            }
+            First(list) => {
+                let v = list.eval(request)?;
+                if let Some(s) = v.first() {
+                    Ok(s.clone())
+                } else {
+                    Err(anyhow!("List is empty."))
+                }
+            }
+            Last(list) => {
+                let v = list.eval(request)?;
+                if let Some(s) = v.last() {
+                    Ok(s.clone())
+                } else {
+                    Err(anyhow!("List is empty."))
+                }
+            }
+        }
+    }
+}
+
+fn map_user_agent<'a, V, F>(request: &HashMap<&str, &'a str>, map: F) -> Result<V>
+where
+    F: FnOnce(WootheeResult<'a>) -> V,
+    V: 'a,
+{
+    if let Some(ua) = request.get("user-agent") {
+        if let Some(ua) = UserAgentParser::new().parse(ua) {
+            Ok(map(ua))
+        } else {
+            Err(anyhow!("Malformed User-Agent string: {}", ua))
+        }
+    } else {
+        Err(anyhow!("User-Agent header not found"))
+    }
+}
+
+fn get_cookie<'a>(request: &HashMap<&str, &'a str>, name: &str) -> Result<&'a str> {
+    let cookie_header = request
+        .get("cookie")
+        .ok_or(anyhow!("No cookies found in request"))?;
+
+    cookie_header
+        .split("; ")
+        .map(|pair| {
+            let items: Vec<_> = pair.split("=").collect();
+
+            (items[0], items[1])
+        })
+        .collect::<HashMap<_, _>>()
+        .get(name)
+        .map(|it| *it)
+        .ok_or(anyhow!("Cookie {} not found", name))
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Num {
+    /// The identity expression
+    Constant(f64),
+    /// Request attribute value
+    Attribute(String),
+    /// Randomly assigns a uniformly distributed stable number between 0.0 and 100.0
+    Rank(Str),
+    /// Looks up a number value by a JSON Pointer
+    ///
+    /// JSON Pointer defines a string syntax for identifying a specific value
+    /// within a JavaScript Object Notation (JSON) document.
+    ///
+    /// A Pointer is a Unicode string with the reference tokens separated by `/`.
+    /// Inside tokens `/` is replaced by `~1` and `~` is replaced by `~0`. The
+    /// addressed value is returned and if there is no such value `None` is
+    /// returned.
+    ///
+    /// For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
+    JsonPointer { pointer: String, value: Str },
+}
+
+impl Num {
+    fn eval(&self, request: &HashMap<&str, &str>) -> Result<f64> {
+        use Num::*;
+        match &self {
+            Constant(c) => Ok(*c),
+            Attribute(name) => {
+                if let Some(s) = request.get::<str>(&name) {
+                    return Ok((*s).parse::<f64>()?);
+                }
+                Err(anyhow!("Attribute '{}' not found.", name))
+            }
+            Rank(str_exp) => str_exp.eval(request).map(|s| {
+                let mut hasher = DefaultHasher::new();
+                s.hash(&mut hasher);
+                (hasher.finish() % 1000) as f64 / 10.0
+            }),
+            JsonPointer { pointer, value } => value
+                .eval(request)
+                .and_then(|json| json_pointer(pointer, &json, "number", |v| v.as_f64())),
+        }
+    }
+}
+
+// Helpers
+
+/// Parse a HTTP q-value of the form '*/*;q=0.3, text/plain;q=0.7, text/html, text/*;q=0.5'
+fn parse_q_value(value: &str) -> Vec<&str> {
+    let mut list: Vec<(&str, f32)> = value
+        .split(',')
+        .map(|q_val| {
+            let mut parts = q_val.split(";q=").map(|it| it.trim());
+            let v = parts.next().unwrap();
+            let q = parts
+                .next()
+                .and_then(|q| q.parse::<f32>().ok())
+                .or_else(|| Some(1.0))
+                .unwrap();
+
+            (v, q)
+        })
+        .collect();
+
+    list.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+
+    list.iter().map(|(v, _)| *v).collect()
+}
+
+// Extract a value out of JSON using a JSON pointer. Useful for JWT tokens for example
+fn json_pointer<'a, T, F>(pointer: &str, json: &'a str, typename: &str, cast: F) -> Result<T>
+where
+    F: FnOnce(&serde_json::Value) -> Option<T>,
+    T: 'a,
+{
+    let value: serde_json::Value = serde_json::from_str(json)?;
+
+    if let Some(inner_value) = value.pointer(pointer) {
+        if let Some(v) = cast(inner_value) {
+            return Ok(v);
+        }
+    }
+
+    Err(anyhow!(
+        "Cannot find a {} at pointer {} in JSON {}",
+        typename,
+        pointer,
+        value
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case(Num::Constant(10.0), Ok(10.0))]
+    #[test_case(Num::Attribute("number".into()), Ok(1.4))]
+    #[test_case(Num::Attribute("nope".into()), Err(anyhow!("Attribute 'nope' not found.")))]
+    #[test_case(Num::Attribute("not-number".into()), Err(anyhow!("invalid float literal")))]
+    #[test_case(Num::Rank(Str::Attribute("not-number".into())), Ok(40.9))]
+    #[test_case(Num::JsonPointer { pointer: "/foo/0".into(), value: Str::Constant(r#"{"foo":[0.3]}"#.into()) }, Ok(0.3))]
+    #[test_case(Num::JsonPointer { pointer: "/bar/0".into(), value: Str::Constant(r#"{"foo":[0.3]}"#.into()) }, Err(anyhow!("Cannot find a number at pointer /bar/0 in JSON {\"foo\":[0.3]}")))]
+    fn evaluate_numerical_expressions(expr: Num, expected: Result<f64>) {
+        let request = [("number", "1.4"), ("not-number", "hi")]
+            .iter()
+            .cloned()
+            .collect();
+
+        let actual = expr.eval(&request);
+        assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
+    }
+
+    #[test_case(Str::Constant("hello".into()), Ok("hello".into()))]
+    #[test_case(Str::Attribute("hello".into()), Ok("world".into()))]
+    #[test_case(Str::Base64(Box::new(Str::Constant("aGVsbG8=".into()))), Ok("hello".into()))]
+    #[test_case(Str::First(Box::new(StrList::Constant(vec!["a".into(), "b".into(), "c".into()]))), Ok("a".into()))]
+    #[test_case(Str::Last(Box::new(StrList::Constant(vec!["a".into(), "b".into(), "c".into()]))), Ok("c".into()))]
+    #[test_case(Str::First(Box::new(StrList::Constant(vec![]))), Err(anyhow!("List is empty.")))]
+    #[test_case(Str::Last(Box::new(StrList::Constant(vec![]))), Err(anyhow!("List is empty.")))]
+    #[test_case(Str::Browser, Ok("Chrome".into()))]
+    #[test_case(Str::BrowserVersion, Ok("83.0.4103.61".into()))]
+    #[test_case(Str::OperatingSystem, Ok("Mac OSX".into()))]
+    #[test_case(Str::JsonPointer { pointer: "/foo/0".into(), value: Box::new(Str::Constant(r#"{"foo":["bar"]}"#.into())) }, Ok("bar".into()))]
+    #[test_case(Str::JsonPointer { pointer: "/foo/0".into(), value: Box::new(Str::Constant(r#"{"foo":[0.3]}"#.into())) }, Err(anyhow!("Cannot find a string at pointer /foo/0 in JSON {\"foo\":[0.3]}")))]
+    fn evaluate_string_expressions(expr: Str, expected: Result<String>) {
+        let request = [
+            ("hello", "world"),
+            (
+                "user-agent",
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        let actual = expr.eval(&request);
+        assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
+    }
+
+    #[test_case(StrList::Constant(vec!["a".into(), "b".into()]), Ok(vec!["a".into(), "b".into()]))]
+    #[test_case(StrList::Split { separator: " ".into(), value: Str::Constant("a b".into())}, Ok(vec!["a".into(), "b".into()]))]
+    #[test_case(StrList::HttpQualityValue(Str::Attribute("accept".into())), Ok(vec!["text/html".into(), "text/plain".into(), "text/*".into(), "*/*".into()]))]
+    fn evaluate_string_list_expressions(expr: StrList, expected: Result<Vec<String>>) {
+        let mut request = HashMap::new();
+        request.insert(
+            "accept",
+            "*/*;q=0.3, text/plain;q=0.7, text/html, text/*;q=0.5",
+        );
+        let actual = expr.eval(&request);
+        assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
+    }
+
+    #[test_case(Bool::Constant(true), Ok(true))]
+    #[test_case(Bool::Attribute("hello".into()), Ok(true))]
+    #[test_case(Bool::Attribute("world".into()), Err(anyhow!("Attribute 'world' not found.")))]
+    #[test_case(Bool::In { list: StrList::Constant(vec!["a".into(), "b".into()]), value: Str::Constant("b".into()) }, Ok(true); "list contains value")]
+    #[test_case(Bool::In { list: StrList::Constant(vec!["a".into(), "b".into()]), value: Str::Constant("c".into()) }, Ok(false); "list doesn't contain value")]
+    #[test_case(Bool::AllIn { list: StrList::Constant(vec!["a".into(), "b".into()]), values: StrList::Constant(vec!["a".into(), "b".into()]) }, Ok(true); "list contains all values")]
+    #[test_case(Bool::AllIn { list: StrList::Constant(vec!["a".into(), "b".into()]), values: StrList::Constant(vec!["a".into(), "c".into()]) }, Ok(false); "list doesn't contain all values")]
+    #[test_case(Bool::AnyIn { list: StrList::Constant(vec!["a".into(), "b".into()]), values: StrList::Constant(vec!["a".into(), "c".into()]) }, Ok(true); "list contains any of the values")]
+    #[test_case(Bool::AnyIn { list: StrList::Constant(vec!["a".into(), "b".into()]), values: StrList::Constant(vec!["c".into(), "d".into()]) }, Ok(false); "list doesn't contain any of the values")]
+    #[test_case(Bool::JsonPointer { pointer: "/foo/0".into(), value: Str::Constant(r#"{"foo":[true]}"#.into()) }, Ok(true))]
+    #[test_case(Bool::JsonPointer { pointer: "/foo/0".into(), value: Str::Constant(r#"{"foo":[0.3]}"#.into()) }, Err(anyhow!("Cannot find a boolean at pointer /foo/0 in JSON {\"foo\":[0.3]}")))]
+    #[test_case(Bool::Matches(r#"\+440?[0-9]{10}"#.into(), Str::Constant("+4407945123456".into())), Ok(true))]
+    #[test_case(Bool::Matches(r#"\+440?[0-9]{10}"#.into(), Str::Constant("+47945123456".into())), Ok(false))]
+    #[test_case(Bool::StrEq(Str::Constant("foo".into()), Str::Constant("foo".into())), Ok(true))]
+    #[test_case(Bool::StrEq(Str::Constant("foo".into()), Str::Constant("bar".into())), Ok(false))]
+    #[test_case(Bool::NumEq(Num::Constant(1.3), Num::Constant(1.3)), Ok(true))]
+    #[test_case(Bool::NumEq(Num::Constant(1.0), Num::Constant(1.3)), Ok(false))]
+    #[test_case(Bool::Gt(Num::Constant(1.3), Num::Constant(1.2)), Ok(true))]
+    #[test_case(Bool::Gt(Num::Constant(1.2), Num::Constant(1.3)), Ok(false))]
+    #[test_case(Bool::Gt(Num::Constant(1.3), Num::Constant(1.3)), Ok(false))]
+    #[test_case(Bool::Gte(Num::Constant(1.3), Num::Constant(1.2)), Ok(true))]
+    #[test_case(Bool::Gte(Num::Constant(1.2), Num::Constant(1.3)), Ok(false))]
+    #[test_case(Bool::Gte(Num::Constant(1.3), Num::Constant(1.3)), Ok(true))]
+    #[test_case(Bool::Lt(Num::Constant(1.3), Num::Constant(1.2)), Ok(false))]
+    #[test_case(Bool::Lt(Num::Constant(1.2), Num::Constant(1.3)), Ok(true))]
+    #[test_case(Bool::Lt(Num::Constant(1.3), Num::Constant(1.3)), Ok(false))]
+    #[test_case(Bool::Lte(Num::Constant(1.3), Num::Constant(1.2)), Ok(false))]
+    #[test_case(Bool::Lte(Num::Constant(1.2), Num::Constant(1.3)), Ok(true))]
+    #[test_case(Bool::Lte(Num::Constant(1.3), Num::Constant(1.3)), Ok(true))]
+    #[test_case(Bool::Not(Box::new(Bool::Constant(true))), Ok(false))]
+    #[test_case(Bool::And(vec![Bool::Constant(true), Bool::Constant(true)]), Ok(true))]
+    #[test_case(Bool::And(vec![Bool::Constant(true), Bool::Constant(false)]), Ok(false))]
+    #[test_case(Bool::Or(vec![Bool::Constant(true), Bool::Constant(false)]), Ok(true))]
+    #[test_case(Bool::Or(vec![Bool::Constant(false), Bool::Constant(false)]), Ok(false))]
+    fn evaluate_boolean_expressions(expr: Bool, expected: Result<bool>) {
+        let request = [("hello", "world")].iter().cloned().collect();
+
+        let actual = expr.eval(&request);
+        assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
+    }
+}

--- a/data-plane/src/features/implicit.rs
+++ b/data-plane/src/features/implicit.rs
@@ -1,12 +1,6 @@
-use anyhow::{anyhow, Result};
-use base64::decode as base64decode;
-use regex::Regex;
+use crate::features::expression::Bool;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{hash_map::DefaultHasher, HashMap, HashSet},
-    hash::{Hash, Hasher},
-};
-use woothee::parser::{Parser as UserAgentParser, WootheeResult};
+use std::collections::HashMap;
 
 /// A set of features and their matching rules
 #[derive(Deserialize, Serialize, Debug)]
@@ -22,7 +16,7 @@ impl Default for Config {
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Feature {
     name: String,
-    rule: BoolExpr,
+    rule: Bool,
 }
 
 pub fn from_request<'a>(request: &HashMap<&str, &str>, config: &'a Config) -> Vec<&'a str> {
@@ -36,499 +30,12 @@ pub fn from_request<'a>(request: &HashMap<&str, &str>, config: &'a Config) -> Ve
         .collect()
 }
 
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum BoolExpr {
-    /// The identity expression
-    Constant(bool),
-    /// Request attribute of name is present
-    Attribute(String),
-    /// Value contained in the list
-    In {
-        list: StringListExpr,
-        value: StringExpr,
-    },
-    /// Any of the values contained in the list
-    AnyIn {
-        list: StringListExpr,
-        values: StringListExpr,
-    },
-    /// All of the values contained in the list
-    AllIn {
-        list: StringListExpr,
-        values: StringListExpr,
-    },
-    /// Looks up a boolean value by a JSON Pointer
-    ///
-    /// JSON Pointer defines a string syntax for identifying a specific value
-    /// within a JavaScript Object Notation (JSON) document.
-    ///
-    /// A Pointer is a Unicode string with the reference tokens separated by `/`.
-    /// Inside tokens `/` is replaced by `~1` and `~` is replaced by `~0`. The
-    /// addressed value is returned and if there is no such value `None` is
-    /// returned.
-    ///
-    /// For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
-    JsonPointer { pointer: String, value: StringExpr },
-    /// Matches a Regular Expression
-    Matches(String, StringExpr),
-    /// == for strings
-    StrEq(StringExpr, StringExpr),
-    /// == for numbers
-    NumEq(NumExpr, NumExpr),
-    /// > for numbers
-    Gt(NumExpr, NumExpr),
-    /// < for numbers
-    Lt(NumExpr, NumExpr),
-    /// >= for numbers
-    Gte(NumExpr, NumExpr),
-    /// <= for numbers
-    Lte(NumExpr, NumExpr),
-    /// Logical NOT
-    Not(Box<BoolExpr>),
-    /// Logical AND
-    And(Vec<BoolExpr>),
-    /// Logical OR
-    Or(Vec<BoolExpr>),
-}
-
-impl BoolExpr {
-    fn eval(&self, request: &HashMap<&str, &str>) -> Result<bool> {
-        use BoolExpr::*;
-        match &self {
-            Constant(c) => Ok(*c),
-            Attribute(name) => request
-                .get::<str>(name.as_ref())
-                .map(|_| true)
-                .ok_or_else(|| anyhow!("Attribute '{}' not found.", name)),
-            In { list, value } => list
-                .eval(request)
-                .and_then(|haystack| value.eval(request).map(|needle| haystack.contains(&needle))),
-            AnyIn { list, values } => list.eval(request).and_then(|haystack| {
-                values.eval(request).map(|needles| {
-                    let a: HashSet<_> = haystack.iter().collect();
-                    let b: HashSet<_> = needles.iter().collect();
-
-                    a.intersection(&b).next().is_some()
-                })
-            }),
-            AllIn { list, values } => list.eval(request).and_then(|haystack| {
-                values.eval(request).map(|needles| {
-                    let a: HashSet<_> = haystack.iter().collect();
-                    let b: HashSet<_> = needles.iter().collect();
-
-                    a.intersection(&b).count() == a.len()
-                })
-            }),
-            JsonPointer { pointer, value } => value
-                .eval(request)
-                .and_then(|json| json_pointer(pointer, json.as_str(), "boolean", |v| v.as_bool())),
-            Matches(regex, value) => {
-                let v = value.eval(request)?;
-                let r = Regex::new(regex)?;
-                Ok(r.is_match(v.as_ref()))
-            }
-            StrEq(left, right) => {
-                let l = left.eval(request)?;
-                let r = right.eval(request)?;
-                Ok(l == r)
-            }
-            NumEq(left, right) => {
-                let l = left.eval(request)?;
-                let r = right.eval(request)?;
-                Ok((l - r).abs() < std::f64::EPSILON)
-            }
-            Gt(left, right) => {
-                let l = left.eval(request)?;
-                let r = right.eval(request)?;
-                Ok(l > r)
-            }
-            Lt(left, right) => {
-                let l = left.eval(request)?;
-                let r = right.eval(request)?;
-                Ok(l < r)
-            }
-            Gte(left, right) => {
-                let l = left.eval(request)?;
-                let r = right.eval(request)?;
-                Ok(l >= r)
-            }
-            Lte(left, right) => {
-                let l = left.eval(request)?;
-                let r = right.eval(request)?;
-                Ok(l <= r)
-            }
-            Not(value) => value.eval(request).map(|v| !v),
-            And(values) => values
-                .iter()
-                .map(|v| v.eval(request))
-                .collect::<Result<Vec<_>, _>>()
-                .map(|it| it.iter().all(|v| *v)),
-            Or(values) => values
-                .iter()
-                .map(|v| v.eval(request))
-                .collect::<Result<Vec<_>, _>>()
-                .map(|it| it.iter().any(|v| *v)),
-        }
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum StringListExpr {
-    /// The identity expression
-    Constant(Vec<String>),
-    /// Split a string value using a separator
-    Split {
-        separator: String,
-        value: StringExpr,
-    },
-    /// Parse a HTTP header with q-values,
-    /// i.e. Accept, Accept-Charset, Accept-Language, Accept-Encoding
-    HttpQualityValue(StringExpr),
-}
-
-impl StringListExpr {
-    fn eval(&self, request: &HashMap<&str, &str>) -> Result<Vec<String>> {
-        use StringListExpr::*;
-        match &self {
-            Constant(c) => Ok(c.clone()),
-            Split { separator, value } => {
-                let s = value.eval(request)?;
-                Ok(s.split(separator).map(|item| item.to_string()).collect())
-            }
-            HttpQualityValue(value) => {
-                let s = value.eval(request)?;
-                Ok(parse_q_value(s.as_str()))
-            }
-        }
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum StringExpr {
-    /// The identity expression
-    Constant(String),
-    /// Request attribute value
-    Attribute(String),
-    /// Base 64 decode value
-    Base64(Box<StringExpr>),
-    /// Derives browser from User-Agent
-    Browser,
-    /// Derives bowser version from User-Agent
-    BrowserVersion,
-    /// Derives operating system from User-Agent
-    OperatingSystem,
-    /// Looks up a string value by a JSON Pointer
-    ///
-    /// JSON Pointer defines a string syntax for identifying a specific value
-    /// within a JavaScript Object Notation (JSON) document.
-    ///
-    /// A Pointer is a Unicode string with the reference tokens separated by `/`.
-    /// Inside tokens `/` is replaced by `~1` and `~` is replaced by `~0`. The
-    /// addressed value is returned and if there is no such value `None` is
-    /// returned.
-    ///
-    /// For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
-    JsonPointer {
-        pointer: String,
-        value: Box<StringExpr>,
-    },
-    /// First item of a list
-    First(Box<StringListExpr>),
-    /// Last item of a list
-    Last(Box<StringListExpr>),
-}
-
-impl StringExpr {
-    fn eval(&self, request: &HashMap<&str, &str>) -> Result<String> {
-        use StringExpr::*;
-        match &self {
-            Constant(c) => Ok(c.clone()),
-            Attribute(name) => request.get::<str>(name.as_ref()).map_or_else(
-                || Err(anyhow!("Attribute '{}' not found.", name)),
-                |s| Ok((*s).to_string()),
-            ),
-            Base64(value) => {
-                let s = value.eval(request)?;
-                let bytes = base64decode(s)?;
-                Ok(String::from_utf8(bytes)?)
-            }
-            Browser => map_user_agent(request, |ua| ua.name.into()),
-            BrowserVersion => map_user_agent(request, |ua| ua.version.into()),
-            OperatingSystem => map_user_agent(request, |ua| ua.os.into()),
-            JsonPointer { pointer, value } => {
-                let json = value.eval(request)?;
-                json_pointer(pointer, json.as_str(), "string", |v| {
-                    v.as_str().map(|s| s.to_string())
-                })
-            }
-            First(list) => {
-                let v = list.eval(request)?;
-                if let Some(s) = v.first() {
-                    Ok(s.clone())
-                } else {
-                    Err(anyhow!("List is empty."))
-                }
-            }
-            Last(list) => {
-                let v = list.eval(request)?;
-                if let Some(s) = v.last() {
-                    Ok(s.clone())
-                } else {
-                    Err(anyhow!("List is empty."))
-                }
-            }
-        }
-    }
-}
-
-fn map_user_agent<V, F: FnOnce(WootheeResult) -> V>(
-    request: &HashMap<&str, &str>,
-    map: F,
-) -> Result<V> {
-    if let Some(ua) = request.get("user-agent") {
-        if let Some(ua) = UserAgentParser::new().parse(ua) {
-            Ok(map(ua))
-        } else {
-            Err(anyhow!("Malformed User-Agent string: {}", ua))
-        }
-    } else {
-        Err(anyhow!("User-Agent header not found"))
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum NumExpr {
-    /// The identity expression
-    Constant(f64),
-    /// Request attribute value
-    Attribute(String),
-    /// Randomly assigns a uniformly distributed stable number between 0.0 and 100.0
-    Rank(StringExpr),
-    /// Looks up a number value by a JSON Pointer
-    ///
-    /// JSON Pointer defines a string syntax for identifying a specific value
-    /// within a JavaScript Object Notation (JSON) document.
-    ///
-    /// A Pointer is a Unicode string with the reference tokens separated by `/`.
-    /// Inside tokens `/` is replaced by `~1` and `~` is replaced by `~0`. The
-    /// addressed value is returned and if there is no such value `None` is
-    /// returned.
-    ///
-    /// For more information read [RFC6901](https://tools.ietf.org/html/rfc6901).
-    JsonPointer { pointer: String, value: StringExpr },
-}
-
-impl NumExpr {
-    fn eval(&self, request: &HashMap<&str, &str>) -> Result<f64> {
-        use NumExpr::*;
-        match &self {
-            Constant(c) => Ok(*c),
-            Attribute(name) => {
-                if let Some(s) = request.get::<str>(name.as_ref()) {
-                    return Ok((*s).parse::<f64>()?);
-                }
-                Err(anyhow!("Attribute '{}' not found.", name))
-            }
-            Rank(str_exp) => str_exp.eval(request).map(|s| {
-                let mut hasher = DefaultHasher::new();
-                s.hash(&mut hasher);
-                (hasher.finish() % 1000) as f64 / 10.0
-            }),
-            JsonPointer { pointer, value } => value
-                .eval(request)
-                .and_then(|json| json_pointer(pointer, json.as_str(), "number", |v| v.as_f64())),
-        }
-    }
-}
-
-// Helpers
-
-/// Parse a HTTP q-value of the form '*/*;q=0.3, text/plain;q=0.7, text/html, text/*;q=0.5'
-fn parse_q_value(value: &str) -> Vec<String> {
-    let mut list: Vec<(&str, f32)> = value
-        .split(',')
-        .map(|q_val| {
-            let mut parts = q_val.split(";q=").map(|it| it.trim());
-            let v = parts.next().unwrap();
-            let q = parts
-                .next()
-                .and_then(|q| q.parse::<f32>().ok())
-                .or_else(|| Some(1.0))
-                .unwrap();
-
-            (v, q)
-        })
-        .collect();
-
-    list.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-
-    list.iter().map(|(v, _)| (*v).to_string()).collect()
-}
-
-// Extract a value out of JSON using a JSON pointer. Useful for JWT tokens for example
-fn json_pointer<T, F>(pointer: &str, json: &str, typename: &str, cast: F) -> Result<T>
-where
-    F: FnOnce(&serde_json::Value) -> Option<T>,
-{
-    let value: serde_json::Value = serde_json::from_str(json)?;
-    if let Some(value) = value.pointer(pointer) {
-        if let Some(v) = cast(value) {
-            return Ok(v);
-        }
-    }
-    Err(anyhow!(
-        "Cannot find a {} at pointer {} in JSON {}",
-        typename,
-        pointer,
-        value
-    ))
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::features::expression::*;
     use pretty_assertions::assert_eq as assert_eq_diff;
     use serde_json::json;
-    use test_case::test_case;
-
-    #[test_case(NumExpr::Constant(10.0), Ok(10.0))]
-    #[test_case(NumExpr::Attribute("number".into()), Ok(1.4))]
-    #[test_case(NumExpr::Attribute("nope".into()), Err(anyhow!("Attribute 'nope' not found.")))]
-    #[test_case(NumExpr::Attribute("not-number".into()), Err(anyhow!("invalid float literal")))]
-    #[test_case(NumExpr::Rank(StringExpr::Attribute("not-number".into())), Ok(40.9))]
-    #[test_case(NumExpr::JsonPointer { pointer: "/foo/0".into(), value: StringExpr::Constant(r#"{"foo":[0.3]}"#.into()) }, Ok(0.3))]
-    #[test_case(NumExpr::JsonPointer { pointer: "/bar/0".into(), value: StringExpr::Constant(r#"{"foo":[0.3]}"#.into()) }, Err(anyhow!("Cannot find a number at pointer /bar/0 in JSON {\"foo\":[0.3]}")))]
-    fn evaluate_numerical_expressions(expr: NumExpr, expected: Result<f64>) {
-        let request = [("number", "1.4"), ("not-number", "hi")]
-            .iter()
-            .cloned()
-            .collect();
-
-        let actual = expr.eval(&request);
-        assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
-    }
-
-    #[test_case(StringExpr::Constant("hello".into()), Ok("hello".into()))]
-    #[test_case(StringExpr::Attribute("hello".into()), Ok("world".into()))]
-    #[test_case(StringExpr::Base64(Box::new(StringExpr::Constant("aGVsbG8=".into()))), Ok("hello".into()))]
-    #[test_case(StringExpr::First(Box::new(StringListExpr::Constant(vec!["a".into(), "b".into(), "c".into()]))), Ok("a".into()))]
-    #[test_case(StringExpr::Last(Box::new(StringListExpr::Constant(vec!["a".into(), "b".into(), "c".into()]))), Ok("c".into()))]
-    #[test_case(StringExpr::First(Box::new(StringListExpr::Constant(vec![]))), Err(anyhow!("List is empty.")))]
-    #[test_case(StringExpr::Last(Box::new(StringListExpr::Constant(vec![]))), Err(anyhow!("List is empty.")))]
-    #[test_case(StringExpr::Browser, Ok("Chrome".into()))]
-    #[test_case(StringExpr::BrowserVersion, Ok("83.0.4103.61".into()))]
-    #[test_case(StringExpr::OperatingSystem, Ok("Mac OSX".into()))]
-    #[test_case(StringExpr::JsonPointer { pointer: "/foo/0".into(), value: Box::new(StringExpr::Constant(r#"{"foo":["bar"]}"#.into())) }, Ok("bar".into()))]
-    #[test_case(StringExpr::JsonPointer { pointer: "/foo/0".into(), value: Box::new(StringExpr::Constant(r#"{"foo":[0.3]}"#.into())) }, Err(anyhow!("Cannot find a string at pointer /foo/0 in JSON {\"foo\":[0.3]}")))]
-    fn evaluate_string_expressions(expr: StringExpr, expected: Result<String>) {
-        let request = [
-            ("hello", "world"),
-            (
-                "user-agent",
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
-            ),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-
-        let actual = expr.eval(&request);
-        assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
-    }
-
-    #[test_case(StringListExpr::Constant(vec!["a".into(), "b".into()]), Ok(vec!["a".into(), "b".into()]))]
-    #[test_case(StringListExpr::Split { separator: " ".into(), value: StringExpr::Constant("a b".into())}, Ok(vec!["a".into(), "b".into()]))]
-    #[test_case(StringListExpr::HttpQualityValue(StringExpr::Attribute("accept".into())), Ok(vec!["text/html".into(), "text/plain".into(), "text/*".into(), "*/*".into()]))]
-    fn evaluate_string_list_expressions(expr: StringListExpr, expected: Result<Vec<String>>) {
-        let mut request = HashMap::new();
-        request.insert(
-            "accept",
-            "*/*;q=0.3, text/plain;q=0.7, text/html, text/*;q=0.5",
-        );
-        let actual = expr.eval(&request);
-        assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
-    }
-
-    #[test_case(BoolExpr::Constant(true), Ok(true))]
-    #[test_case(BoolExpr::Attribute("hello".into()), Ok(true))]
-    #[test_case(BoolExpr::Attribute("world".into()), Err(anyhow!("Attribute 'world' not found.")))]
-    #[test_case(BoolExpr::In { list: StringListExpr::Constant(vec!["a".into(), "b".into()]), value: StringExpr::Constant("b".into()) }, Ok(true); "list contains value")]
-    #[test_case(BoolExpr::In { list: StringListExpr::Constant(vec!["a".into(), "b".into()]), value: StringExpr::Constant("c".into()) }, Ok(false); "list doesn't contain value")]
-    #[test_case(BoolExpr::AllIn { list: StringListExpr::Constant(vec!["a".into(), "b".into()]), values: StringListExpr::Constant(vec!["a".into(), "b".into()]) }, Ok(true); "list contains all values")]
-    #[test_case(BoolExpr::AllIn { list: StringListExpr::Constant(vec!["a".into(), "b".into()]), values: StringListExpr::Constant(vec!["a".into(), "c".into()]) }, Ok(false); "list doesn't contain all values")]
-    #[test_case(BoolExpr::AnyIn { list: StringListExpr::Constant(vec!["a".into(), "b".into()]), values: StringListExpr::Constant(vec!["a".into(), "c".into()]) }, Ok(true); "list contains any of the values")]
-    #[test_case(BoolExpr::AnyIn { list: StringListExpr::Constant(vec!["a".into(), "b".into()]), values: StringListExpr::Constant(vec!["c".into(), "d".into()]) }, Ok(false); "list doesn't contain any of the values")]
-    #[test_case(BoolExpr::JsonPointer { pointer: "/foo/0".into(), value: StringExpr::Constant(r#"{"foo":[true]}"#.into()) }, Ok(true))]
-    #[test_case(BoolExpr::JsonPointer { pointer: "/foo/0".into(), value: StringExpr::Constant(r#"{"foo":[0.3]}"#.into()) }, Err(anyhow!("Cannot find a boolean at pointer /foo/0 in JSON {\"foo\":[0.3]}")))]
-    #[test_case(BoolExpr::Matches(r#"\+440?[0-9]{10}"#.into(), StringExpr::Constant("+4407945123456".into())), Ok(true))]
-    #[test_case(BoolExpr::Matches(r#"\+440?[0-9]{10}"#.into(), StringExpr::Constant("+47945123456".into())), Ok(false))]
-    #[test_case(BoolExpr::StrEq(StringExpr::Constant("foo".into()), StringExpr::Constant("foo".into())), Ok(true))]
-    #[test_case(BoolExpr::StrEq(StringExpr::Constant("foo".into()), StringExpr::Constant("bar".into())), Ok(false))]
-    #[test_case(
-        BoolExpr::NumEq(NumExpr::Constant(1.3), NumExpr::Constant(1.3)),
-        Ok(true)
-    )]
-    #[test_case(
-        BoolExpr::NumEq(NumExpr::Constant(1.0), NumExpr::Constant(1.3)),
-        Ok(false)
-    )]
-    #[test_case(BoolExpr::Gt(NumExpr::Constant(1.3), NumExpr::Constant(1.2)), Ok(true))]
-    #[test_case(
-        BoolExpr::Gt(NumExpr::Constant(1.2), NumExpr::Constant(1.3)),
-        Ok(false)
-    )]
-    #[test_case(
-        BoolExpr::Gt(NumExpr::Constant(1.3), NumExpr::Constant(1.3)),
-        Ok(false)
-    )]
-    #[test_case(
-        BoolExpr::Gte(NumExpr::Constant(1.3), NumExpr::Constant(1.2)),
-        Ok(true)
-    )]
-    #[test_case(
-        BoolExpr::Gte(NumExpr::Constant(1.2), NumExpr::Constant(1.3)),
-        Ok(false)
-    )]
-    #[test_case(
-        BoolExpr::Gte(NumExpr::Constant(1.3), NumExpr::Constant(1.3)),
-        Ok(true)
-    )]
-    #[test_case(
-        BoolExpr::Lt(NumExpr::Constant(1.3), NumExpr::Constant(1.2)),
-        Ok(false)
-    )]
-    #[test_case(BoolExpr::Lt(NumExpr::Constant(1.2), NumExpr::Constant(1.3)), Ok(true))]
-    #[test_case(
-        BoolExpr::Lt(NumExpr::Constant(1.3), NumExpr::Constant(1.3)),
-        Ok(false)
-    )]
-    #[test_case(
-        BoolExpr::Lte(NumExpr::Constant(1.3), NumExpr::Constant(1.2)),
-        Ok(false)
-    )]
-    #[test_case(
-        BoolExpr::Lte(NumExpr::Constant(1.2), NumExpr::Constant(1.3)),
-        Ok(true)
-    )]
-    #[test_case(
-        BoolExpr::Lte(NumExpr::Constant(1.3), NumExpr::Constant(1.3)),
-        Ok(true)
-    )]
-    #[test_case(BoolExpr::Not(Box::new(BoolExpr::Constant(true))), Ok(false))]
-    #[test_case(BoolExpr::And(vec![BoolExpr::Constant(true), BoolExpr::Constant(true)]), Ok(true))]
-    #[test_case(BoolExpr::And(vec![BoolExpr::Constant(true), BoolExpr::Constant(false)]), Ok(false))]
-    #[test_case(BoolExpr::Or(vec![BoolExpr::Constant(true), BoolExpr::Constant(false)]), Ok(true))]
-    #[test_case(BoolExpr::Or(vec![BoolExpr::Constant(false), BoolExpr::Constant(false)]), Ok(false))]
-    fn evaluate_boolean_expressions(expr: BoolExpr, expected: Result<bool>) {
-        let request = [("hello", "world")].iter().cloned().collect();
-
-        let actual = expr.eval(&request);
-        assert_eq!(format!("{:?}", actual), format!("{:?}", expected));
-    }
 
     #[test]
     fn matches_a_complex_expression() {
@@ -540,56 +47,40 @@ mod test {
         let config = Config(vec![
             Feature {
                 name: "english".into(),
-                rule: BoolExpr::AnyIn {
-                    list: StringListExpr::Constant(vec![
-                        "en".into(),
-                        "en-US".into(),
-                        "en-GB".into(),
-                    ]),
-                    values: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                        "accept-language".into(),
-                    )),
+                rule: Bool::AnyIn {
+                    list: StrList::Constant(vec!["en".into(), "en-US".into(), "en-GB".into()]),
+                    values: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
                 },
             },
             Feature {
                 name: "other-english".into(),
-                rule: BoolExpr::Or(vec![
-                    BoolExpr::In {
-                        list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                            "accept-language".into(),
-                        )),
-                        value: StringExpr::Constant("en".into()),
+                rule: Bool::Or(vec![
+                    Bool::In {
+                        list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                        value: Str::Constant("en".into()),
                     },
-                    BoolExpr::In {
-                        list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                            "accept-language".into(),
-                        )),
-                        value: StringExpr::Constant("en-US".into()),
+                    Bool::In {
+                        list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                        value: Str::Constant("en-US".into()),
                     },
-                    BoolExpr::In {
-                        list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                            "accept-language".into(),
-                        )),
-                        value: StringExpr::Constant("en-GB".into()),
+                    Bool::In {
+                        list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                        value: Str::Constant("en-GB".into()),
                     },
                 ]),
             },
             Feature {
                 name: "british".into(),
-                rule: BoolExpr::In {
-                    list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                        "accept-language".into(),
-                    )),
-                    value: StringExpr::Constant("en-GB".into()),
+                rule: Bool::In {
+                    list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                    value: Str::Constant("en-GB".into()),
                 },
             },
             Feature {
                 name: "german".into(),
-                rule: BoolExpr::In {
-                    list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                        "accept-language".into(),
-                    )),
-                    value: StringExpr::Constant("de".into()),
+                rule: Bool::In {
+                    list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                    value: Str::Constant("de".into()),
                 },
             },
         ]);
@@ -605,47 +96,33 @@ mod test {
         let config = Config(vec![
             Feature {
                 name: "english".into(),
-                rule: BoolExpr::AnyIn {
-                    list: StringListExpr::Constant(vec![
-                        "en".into(),
-                        "en-US".into(),
-                        "en-GB".into(),
-                    ]),
-                    values: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                        "accept-language".into(),
-                    )),
+                rule: Bool::AnyIn {
+                    list: StrList::Constant(vec!["en".into(), "en-US".into(), "en-GB".into()]),
+                    values: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
                 },
             },
             Feature {
                 name: "other-english".into(),
-                rule: BoolExpr::Or(vec![
-                    BoolExpr::In {
-                        list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                            "accept-language".into(),
-                        )),
-                        value: StringExpr::Constant("en".into()),
+                rule: Bool::Or(vec![
+                    Bool::In {
+                        list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                        value: Str::Constant("en".into()),
                     },
-                    BoolExpr::In {
-                        list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                            "accept-language".into(),
-                        )),
-                        value: StringExpr::Constant("en-US".into()),
+                    Bool::In {
+                        list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                        value: Str::Constant("en-US".into()),
                     },
-                    BoolExpr::In {
-                        list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                            "accept-language".into(),
-                        )),
-                        value: StringExpr::Constant("en-GB".into()),
+                    Bool::In {
+                        list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                        value: Str::Constant("en-GB".into()),
                     },
                 ]),
             },
             Feature {
                 name: "british".into(),
-                rule: BoolExpr::In {
-                    list: StringListExpr::HttpQualityValue(StringExpr::Attribute(
-                        "accept-language".into(),
-                    )),
-                    value: StringExpr::Constant("en-GB".into()),
+                rule: Bool::In {
+                    list: StrList::HttpQualityValue(Str::Attribute("accept-language".into())),
+                    value: Str::Constant("en-GB".into()),
                 },
             },
         ]);

--- a/data-plane/src/features/mod.rs
+++ b/data-plane/src/features/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 pub mod explicit;
+pub mod expression;
 pub mod implicit;
 
 pub fn target<'a>(
@@ -9,7 +10,11 @@ pub fn target<'a>(
     implicit_config: &implicit::Config,
 ) -> String {
     union(
-        target_explicit(request, explicit_config).as_ref(),
+        target_explicit(request, explicit_config)
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .as_ref(),
         target_implicit(request, implicit_config).as_ref(),
     )
 }
@@ -23,15 +28,12 @@ pub fn union(existing: &[&str], new: &[&str]) -> String {
     result.join(" ")
 }
 
-pub fn target_explicit<'a>(
-    request: &HashMap<&str, &'a str>,
-    config: &explicit::Config,
-) -> Vec<&'a str> {
+pub fn target_explicit(request: &HashMap<&str, &str>, config: &explicit::Config) -> Vec<String> {
     explicit::from_request(request, config)
 }
 
 pub fn target_implicit<'a>(
-    request: &HashMap<&str, &'a str>,
+    request: &HashMap<&str, &str>,
     config: &'a implicit::Config,
 ) -> Vec<&'a str> {
     implicit::from_request(request, config)

--- a/examples/wasm-envoy-filter/2-adapter/envoy-filter.yaml
+++ b/examples/wasm-envoy-filter/2-adapter/envoy-filter.yaml
@@ -31,15 +31,23 @@ spec:
                     "header_name": "x-features",
                     "explicit": [
                       {
-                        "_extract": "list",
-                        "attribute": "x-feature-override"
+                        "split": {
+                          "separator": " ",
+                          "value": {
+                            "attribute": "x-feature-override"
+                          }
+                        }
                       },
                       {
-                        "_extract": "pattern",
-                        "attribute": ":authority",
-                        "pattern": "f-*.localhost"
+                        "extract": {
+                          "regex": "f-([a-z0-9-]+)",
+                          "value": {
+                            "attribute": ":authority"
+                          }
+                        }
                       }
-                    ]
+                    ],
+                    "implicit": []
                   }
                 root_id: redbadger.feature_targeting
                 vm_config:


### PR DESCRIPTION
... to use expressions across explicit and implicit targeting configuration. The only real difference is that implicit configuration consists of (named) boolean expression, explicit configuration consists of string list expressions, which extract header names out of the request. 

I've also extracted the expression logic into it's own module and shortened their names. I will likely break it down further by output type, because the ~500 line file is a bit unwieldy to navigate, which is why the module is in a subfolder. I think I'll also probably come up with a more concise syntax to write the config expressions in.

There may be an additional bit of flexibility to eek out by implementing a `StrList::Tuple(Vec<Str>)` variant on the `StrList` expression, enabling the full extent of `Str` to be used with explicit config as well. Not sure this is needed, but we can add that if we encounter a case which can't creatively use `StrList::Split`.

- [x] Use expressions for explicit targeting
- [x] Add regex matching and cookie parser expressions and tests
- [x] Update example configs across the codebase. **this is a breaking change**